### PR TITLE
Version with statically fused fusedcpdef_sigindex

### DIFF
--- a/Cython/Compiler/ParseTreeTransforms.py
+++ b/Cython/Compiler/ParseTreeTransforms.py
@@ -1610,14 +1610,7 @@ if VALUE is not None:
         node.analyse_declarations(self.current_env())
         self.visitchildren(node)
         self.seen_vars_stack.pop()
-        print("Visiting ModuleNode", node)
-        print(node.scope)
-        print(node.body)
-        print(node.body.stats)
-        print(self.module_contains_fusedcpdefs)
-        if self.module_contains_fusedcpdefs:
-            pass
-            self._inject_fusedcpdef_sigindex(node)
+
          #   node.body.stats.insert(0, self._inject_fusedcpdef_sigindex(node))
         node.body.stats.extend(self.extra_module_declarations)
         return node
@@ -1646,29 +1639,6 @@ if VALUE is not None:
                 and not node.scope.lookup('__reduce_ex__')):
                 self._inject_pickle_methods(node)
         return node
-
-    def _inject_fusedcpdef_sigindex(self, node):
-        # print("Injecting `fusedcpdef` stuff", node)
-        sigindex_dict = TreeFragment(
-            #cdef dict %(fused_cpdef_globalindex)s
-            # FIXME: Statically type this.
-            u"""
-            %(fused_cpdef_globalindex)s = {}
-            """ % {'fused_cpdef_globalindex': Naming.fused_cpdef_globalindex},
-            level = 'module',
-            pipeline = [NormalizeTree(None)]
-        ).substitute({})
-        # print(sigindex_dict)
-        #self.visit(sigindex_dict)
-        #print(sorted(dir(node.node)))
-        #print(node.node)
-        #print(node.node.entry)
-        # print(node.scope)
-        sigindex_dict.analyse_declarations(node.scope)
-        #return sigindex_dict
-        self.extra_module_declarations.append(sigindex_dict)
-        # print(self.extra_module_declarations)
-        # print(self)
 
     def _inject_pickle_methods(self, node):
         env = self.current_env()

--- a/Cython/Compiler/Symtab.py
+++ b/Cython/Compiler/Symtab.py
@@ -1212,7 +1212,6 @@ class ModuleScope(Scope):
         for var_name in ['__builtins__', '__name__', '__file__', '__doc__', '__path__',
                          '__spec__', '__loader__', '__package__', '__cached__']:
             self.declare_var(EncodedString(var_name), py_object_type, None)
-        self.declare_var(EncodedString(Naming.fused_cpdef_globalindex), Builtin.dict_type, None, is_cdef=True)
         self.process_include(Code.IncludeCode("Python.h", initial=True))
 
     def qualifying_scope(self):

--- a/tests/run/fused_cpdef.pyx
+++ b/tests/run/fused_cpdef.pyx
@@ -84,6 +84,7 @@ def test_midimport_run():
     A, x is long 2 long
     A, x is long 2 long
     A, x is long 2 long
+    <BLANKLINE>
     """
     print midimport_run
 


### PR DESCRIPTION
It looks like you're struggling to get this to work.

Here's a version with a statically typed fusedcpdef_sigindex that I think is OK. (I've only done `runtest.py fused` though....). It does the declaration in the fused_node rather than in ParseTreeTransforms. The declaration doesn't generate any initialization code, hence I do the `is None` check, and initialize it if necessary.

I did have to add a `<BLANKLINE>` in one of the tests and I don't really understand why, so you might want to double-check that.